### PR TITLE
Use sample.trimmed2 in Quant-seq pipeline

### DIFF
--- a/pipelines/quantseq.py
+++ b/pipelines/quantseq.py
@@ -214,7 +214,7 @@ def process(args, prj, sample):
     pipe.timestamp("Quantifying read counts with kallisto")
     cmd = tk.kallisto(
         inputFastq=sample.trimmed1 if sample.paired else sample.trimmed,
-        inputFastq2=sample.trimmed1 if sample.paired else None,
+        inputFastq2=sample.trimmed2 if sample.paired else None,
         outputDir=sample.dirs.quant,
         outputBam=sample.pseudomapped,
         transcriptomeIndex=prj.config["annotations"]["kallistoindex"][sample.genome],


### PR DESCRIPTION
I believe that the `inputFastq2` parameter is being incorrectly passed `sample.trimmed1` when it should be `sample.trimmed2`.